### PR TITLE
Introduction of S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 /public/uploads/message/image/
 /public/uploads/tmp/
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'paperclip'
 gem 'carrierwave'
 gem 'fog'
 gem 'rmagick'
+gem 'dotenv-rails'
+gem 'config'
 
 group :test do
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,11 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     concurrent-ruby (1.0.2)
+    config (1.3.0)
+      activesupport (>= 3.0)
+      deep_merge (~> 1.1.1)
     debug_inspector (0.0.2)
+    deep_merge (1.1.1)
     devise (4.2.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -72,6 +76,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     excon (0.54.0)
     execjs (2.7.0)
@@ -380,7 +388,9 @@ DEPENDENCIES
   byebug
   carrierwave
   coffee-rails (~> 4.1.0)
+  config
   devise
+  dotenv-rails
   factory_girl_rails (~> 4.4.1)
   faker
   fog

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -7,8 +7,14 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  case Rails.env
+    when 'production'
+      storage :fog
+    when 'development'
+      storage :fog
+    when 'test'
+      storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,4 +7,16 @@ CarrierWave.configure do |config|
     region: 'ap-northeast-1'
   }
 
+  case Rails.env
+    when 'production'
+      config.fog_directory = 's3tai'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/s3tai-bucket'
+
+    when 'development'
+      config.fog_directory = 's3tai-bucket'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/s3tai-bucket'
+
+    when 'test'
+      config.storage = :file
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,10 @@
+CarrierWave.configure do |config|
+
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    region: 'ap-northeast-1'
+  }
+
+end


### PR DESCRIPTION
# what
1. gem ’dotenv’ installs.
2. it configures the storage by each environment.
3. it sets ‘.env’ to ’.gitignore’

# why
 not to reduce the capacity of the storage in local files
